### PR TITLE
Integrating with heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: main

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: main
+web: narcotk-hosts

--- a/main.go
+++ b/main.go
@@ -184,16 +184,15 @@ func main() {
 		os.Exit(0)
 	}
 
+	StartPaas()
+
 	if viper.GetBool("startweb") {
 		startWeb(viper.GetString("Database"), viper.GetString("ListenIP"), viper.GetString("ListenPort"), viper.GetBool("EnableTLS"))
 		os.Exit(0)
 	}
 
-	if true {
-		//if viper.GetBool("starthttp") {
-		port := os.Getenv("PORT")
-		startWeb(viper.GetString("Database"), viper.GetString("ListenIP"), port, false)
-		//startWeb(viper.GetString("Database"), viper.GetString("ListenIP"), viper.GetString("ListenPort"), false)
+	if viper.GetBool("starthttp") {
+		startWeb(viper.GetString("Database"), viper.GetString("ListenIP"), viper.GetString("ListenPort"), false)
 		os.Exit(0)
 	}
 
@@ -826,6 +825,21 @@ func MakePaddedIp(ipaddress string) string {
 	paddedIp := PadLeft(s[0]) + PadLeft(s[1]) + PadLeft(s[2]) + PadLeft(s[3])
 	//fmt.Printf("P=%s\n", paddedIp)
 	return paddedIp
+}
+
+func StartPaas() {
+	port := os.Getenv("PORT")
+	if port != "" {
+		log.Println("PORT environment set, overiding configuration and starting PaaS mode")
+		log.Println("Original: ListenIP:", viper.GetString("ListenIP"), "  ListenPort: ", viper.GetBool("ListenPort"), "  EnableTLS: ", viper.GetBool("EnableTLS"), "  startweb: ", viper.GetBool("startweb"))
+		viper.Set("ListenIP", "0.0.0.0")
+		viper.Set("ListenPort", port)
+		viper.Set("EnableTLS", false)
+		viper.Set("startweb", true)
+		log.Println("PaaS Mode: ListenIP:", viper.GetString("ListenIP"), "  ListenPort: ", viper.GetBool("ListenPort"), "  EnableTLS: ", viper.GetBool("EnableTLS"), "  startweb: ", viper.GetBool("startweb"))
+	} else {
+		log.Println("No PORT environment variable set, not starting in PaaS mode")
+	}
 }
 
 func displayHelp() {

--- a/main.go
+++ b/main.go
@@ -62,7 +62,6 @@ func displayConfig() {
 	fmt.Printf("ShowHeader:      %s\n", viper.GetString("ShowHeader"))
 	fmt.Printf("ListenPort:      %s\n", viper.GetString("ListenPort"))
 	fmt.Printf("ListenIP:        %s\n", viper.GetString("ListenIP"))
-	fmt.Printf("Verbose:         %s\n", viper.GetString("Verbose"))
 	fmt.Printf("Database:        %s\n", viper.GetString("Database"))
 	fmt.Printf("HeaderFile:      %s\n", viper.GetString("HeaderFile"))
 	fmt.Printf("Files:           %s\n", viper.GetString("Files"))
@@ -71,6 +70,7 @@ func displayConfig() {
 	fmt.Printf("TLSCert:         %s\n", viper.GetString("TLSCert"))
 	fmt.Printf("TLSKey:          %s\n", viper.GetString("TLSKey"))
 	fmt.Printf("RegistrationKey: %s\n", viper.GetString("RegistationKey"))
+	fmt.Printf("Verbose:         %s\n", viper.GetString("Verbose"))
 }
 
 func PrepareMac(macaddress string) string {
@@ -160,6 +160,7 @@ func init() {
 		viper.SetDefault("TLSCert", "./tls/server.crt")
 		viper.SetDefault("TLSKey", "./tls/server.key")
 		viper.SetDefault("RegistrationKey", "")
+		viper.SetDefault("Verbose", true)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -188,8 +188,11 @@ func main() {
 		os.Exit(0)
 	}
 
-	if viper.GetBool("starthttp") {
-		startWeb(viper.GetString("Database"), viper.GetString("ListenIP"), viper.GetString("ListenPort"), false)
+	if true {
+		//if viper.GetBool("starthttp") {
+		port := os.Getenv("PORT")
+		startWeb(viper.GetString("Database"), viper.GetString("ListenIP"), port, false)
+		//startWeb(viper.GetString("Database"), viper.GetString("ListenIP"), viper.GetString("ListenPort"), false)
 		os.Exit(0)
 	}
 

--- a/narco-hosts-config.json
+++ b/narco-hosts-config.json
@@ -3,7 +3,7 @@
     "EnableTLS": false,
     "HeaderFile": "./header.txt",
     "JSON": false,
-    "ListenIP": "0.0.0.0",
+    "ListenIP": "127.0.0.1",
     "ListenPort": "23000",
     "Files": "./files",
     "ShowHeader": false,

--- a/narco-hosts-config.json
+++ b/narco-hosts-config.json
@@ -3,7 +3,7 @@
     "EnableTLS": false,
     "HeaderFile": "./header.txt",
     "JSON": false,
-    "ListenIP": "127.0.0.1",
+    "ListenIP": "0.0.0.0",
     "ListenPort": "23000",
     "Files": "./files",
     "ShowHeader": false,


### PR DESCRIPTION
Detects whether PORT environment variable is set and if set:
- changes app to listen on 0.0.0.0 (all ips)
- sets the app to listen on the PORT defined environment variable
- starts the app in http mode (as TLS termination is done by the Paas)
- compatible with heroku and cloudfoundry